### PR TITLE
Make sure `ls-lisp` is loaded before advicing its functions

### DIFF
--- a/dired-du.el
+++ b/dired-du.el
@@ -153,6 +153,8 @@
 (require 'cl-lib)
 (require 'dired)
 (require 'find-dired)
+(require 'ls-lisp)
+
 (autoload 'dired-subdir-min "dired-aux")
 
 (defgroup dired-du nil


### PR DESCRIPTION
Otherwise the advise are not taken into account and nothing happens when one tries to sort by size